### PR TITLE
Use pycdlib to read all the needed data without the need for mounting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ Compatibility
 
 Works for Python versions 2 and 3, from 2.6 through to the nightly build.
 
+Support for Windows, Mac OS and Linux.
+
 Availability
 ============
 
@@ -53,7 +55,7 @@ From the shell:
 
 .. code-block:: sh
 
-    steve@babbage:~$ crc64=$(pydvdid /mnt/dvd)
+    steve@babbage:~$ crc64=$(pydvdid /mnt/dvd)  // or "/dev/sr0"
     steve@babbage:~$ echo $crc64
     6e23e6a41a154405
     steve@babbage:~$ curl --get http://metaservices.windowsmedia.com/pas_dvd_B/template/GetMDRDVDByCRC.xml?CRC=$crc64
@@ -70,7 +72,7 @@ pydvdid has a decidely simple API, with the important bits imported into the pac
 .. code-block:: python
 
     >>> from pydvdid import compute
-    >>> crc64 = compute("/mnt/dvd")
+    >>> crc64 = compute("/mnt/dvd")  # or "/dev/sr0", or "E:" e.t.c
     >>> str(crc64)
     'a5acf20f2e56954b'
     >>> from urllib import urlopen

--- a/pydvdid/functions.py
+++ b/pydvdid/functions.py
@@ -5,11 +5,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from datetime import datetime
+from dateutil.tz import tzoffset
+from io import BytesIO
 from os import listdir
 from os.path import (
     basename, getctime, getsize, isdir, isfile, join
 )
 from struct import pack_into
+import pycdlib
 from .crc64calculator import _Crc64Calculator
 from .exceptions import (
     FileContentReadException, FileTimeOutOfRangeException, PathDoesNotExistException
@@ -21,80 +24,78 @@ def compute(dvd_path):
        checksum from the DVD .vob, .ifo and .bup files found in the supplied DVD path.
     """
 
-    _check_dvd_path_exists(dvd_path)
+    dvd = pycdlib.PyCdlib()
 
-    _check_video_ts_path_exists(dvd_path)
+    try:
+        dvd.open(dvd_path)
+    except:
+        raise FileContentReadException(dvd_path)
+
+    _check_video_ts_path_exists(dvd)
 
     # the polynomial used for this CRC-64 checksum is:
     # x^63 + x^60 + x^57 + x^55 + x^54 + x^50 + x^49 + x^46 + x^41 + x^38 + x^37 + x^34 + x^32 +
     # x^31 + x^30 + x^28 + x^25 + x^24 + x^21 + x^16 + x^13 + x^12 + x^11 + x^8 + x^7 + x^5 + x^2
     calculator = _Crc64Calculator(0x92c64265d32139a4)
 
-    for video_ts_file_path in _get_video_ts_file_paths(dvd_path):
-        calculator.update(_get_file_creation_time(video_ts_file_path))
-        calculator.update(_get_file_size(video_ts_file_path))
-        calculator.update(_get_file_name(video_ts_file_path))
-
-    calculator.update(_get_vmgi_file_content(dvd_path))
-    calculator.update(_get_vts01i_file_content(dvd_path))
+    for vob, file_path in _get_video_ts_files(dvd):
+        calculator.update(_get_file_creation_time(vob))
+        calculator.update(_get_file_size(vob))
+        calculator.update(_get_file_name(file_path))
+    for vob, file_path in _get_video_ts_files(dvd):
+        if basename(file_path) in ["VIDEO_TS.IFO", "VTS_01_0.IFO"]:
+            calculator.update(_get_first_64k_content(dvd, vob))
 
     return calculator.crc64
 
 
-def _check_dvd_path_exists(dvd_path):
-    """Raises an exception if the specified DVD path does not exist.
-    """
-
-    if not isdir(dvd_path):
-        raise PathDoesNotExistException(dvd_path)
-
-
-def _check_video_ts_path_exists(dvd_path):
+def _check_video_ts_path_exists(dvd):
     """Raises an exception if the specified DVD path does not contain a VIDEO_TS folder.
     """
 
-    video_ts_folder_path = join(dvd_path, "VIDEO_TS")
+    files = dvd.list_children(iso_path="/VIDEO_TS")
+    if not files:
+        raise PathDoesNotExistException("/VIDEO_TS")
 
-    if not isdir(video_ts_folder_path):
-        raise PathDoesNotExistException(video_ts_folder_path)
 
-
-def _get_video_ts_file_paths(dvd_path):
-    """Returns a sorted list of paths for files contained in th VIDEO_TS folder of the specified
+def _get_video_ts_files(dvd):
+    """Returns a sorted list of paths for files contained in the VIDEO_TS folder of the specified
        DVD path.
     """
 
-    video_ts_folder_path = join(dvd_path, "VIDEO_TS")
+    for vob in dvd.list_children(iso_path="/VIDEO_TS"):
+        file_path = vob.file_identifier().decode()
+        # skip the `.` and `..` paths
+        if file_path in [".", ".."]:
+            continue
+        # remove the semicolon and version number
+        if ";" in file_path:
+            file_path = file_path.split(";")[0]
+        # join it to root to be absolute
+        file_path = join("/VIDEO_TS", file_path)
+        # we can just yield, it's already in a good enough order
+        yield vob, file_path
 
-    video_ts_file_paths = []
 
-    for video_ts_folder_content_name in listdir(video_ts_folder_path):
-        video_ts_folder_content_path = join(video_ts_folder_path, video_ts_folder_content_name)
-
-        if isfile(video_ts_folder_content_path):
-            video_ts_file_paths.append(video_ts_folder_content_path)
-
-    return sorted(video_ts_file_paths)
-
-
-def _get_file_creation_time(file_path):
+def _get_file_creation_time(vob):
     """Returns the creation time of the file at the specified file path in Microsoft FILETIME
        structure format (https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284.aspx),
        formatted as a 8-byte unsigned integer bytearray.
     """
 
-    ctime = getctime(file_path)
+    dt = datetime(
+        year=1900 + vob.date.years_since_1900, month=vob.date.month, day=vob.date.day_of_month,
+        hour=vob.date.hour, minute=vob.date.minute, second=vob.date.second,
+        # offset the timezone, since ISO's dates are offsets of GMT in 15 minute intervals, we
+        # need to calculate that but in seconds to pass to tzoffset.
+        tzinfo=tzoffset("GMT", (15 * vob.date.gmtoffset) * 60)
+    )
 
-    if ctime < -11644473600 or ctime >= 253402300800:
-        raise FileTimeOutOfRangeException(ctime)
+    epoch_offset = dt - datetime(1601, 1, 1, tzinfo=tzoffset(None, 0))
 
-    creation_time_datetime = datetime.utcfromtimestamp(ctime)
+    secs_from_epoch = _convert_timedelta_to_seconds(epoch_offset)
 
-    creation_time_epoch_offset = creation_time_datetime - datetime(1601, 1, 1)
-
-    creation_time_secs_from_epoch = _convert_timedelta_to_seconds(creation_time_epoch_offset)
-
-    creation_time_filetime = int(creation_time_secs_from_epoch * (10 ** 7))
+    creation_time_filetime = int(secs_from_epoch * (10 ** 7))
 
     file_creation_time = bytearray(8)
     pack_into(b"Q", file_creation_time, 0, creation_time_filetime)
@@ -112,12 +113,12 @@ def _convert_timedelta_to_seconds(timedelta):
     return int((timedelta.microseconds + (timedelta.seconds + days_in_seconds) * 10 ** 6) / 10 ** 6)
 
 
-def _get_file_size(file_path):
+def _get_file_size(vob):
     """Returns the size of the file at the specified file path, formatted as a 4-byte unsigned
        integer bytearray.
     """
 
-    size = getsize(file_path)
+    size = vob.get_data_length()
 
     file_size = bytearray(4)
     pack_into(b"I", file_size, 0, size)
@@ -125,12 +126,12 @@ def _get_file_size(file_path):
     return file_size
 
 
-def _get_file_name(file_path):
+def _get_file_name(vob):
     """Returns the name of the file at the specified file path, formatted as a UTF-8 bytearray
        terminated with a null character.
     """
 
-    file_name = basename(file_path)
+    file_name = basename(vob)
 
     utf8_file_name = bytearray(file_name, "utf8")
     utf8_file_name.append(0)
@@ -138,43 +139,25 @@ def _get_file_name(file_path):
     return utf8_file_name
 
 
-def _get_vmgi_file_content(dvd_path):
-    """Returns the first 65536 bytes (or the file size, whichever is smaller) of the VIDEO_TS.IFO
-       file in the VIDEO_TS folder of the specified DVD path, as a bytearray.
-    """
-
-    vmgi_file_path = join(dvd_path, "VIDEO_TS", "VIDEO_TS.IFO")
-
-    return _get_first_64k_content(vmgi_file_path)
-
-
-def _get_vts01i_file_content(dvd_path):
-    """Returns the first 65536 (or the file size, whichever is smaller) bytes of the VTS_01_0.IFO
-       file in the VIDEO_TS folder of the specified DVD path, as a bytearray.
-    """
-
-    vts01i_file_path = join(dvd_path, "VIDEO_TS", "VTS_01_0.IFO")
-
-    return _get_first_64k_content(vts01i_file_path)
-
-
-def _get_first_64k_content(file_path):
+def _get_first_64k_content(dvd, vob):
     """Returns the first 65536 (or the file size, whichever is smaller) bytes of the file at the
        specified file path, as a bytearray.
     """
 
-    if not isfile(file_path):
-        raise PathDoesNotExistException(file_path)
+    read_size = min(vob.get_data_length(), 0x10000)
 
-    file_size = getsize(file_path)
+    # perhaps find a way to read a specific amount of bytes rather than the full file
+    # i dont see a way to without having to grab the lba and manually read with a device
+    # handle, which is like kinda eww -git/rlaPHOENiX ; todo
+    f = BytesIO()
+    dvd.get_file_from_iso_fp(
+        outfp=f,
+        iso_path=f"/VIDEO_TS/{vob.file_identifier().decode()}"
+    )
+    f.seek(0)  # go back to start after writing data above
+    content = f.read(read_size)
 
-    content_size = min(file_size, 0x10000)
-
-    content = bytearray(content_size)
-    with open(file_path, "rb") as file_object:
-        content_read = file_object.readinto(content)
-
-        if content_read is None or content_read < content_size:
-            raise FileContentReadException(content_size, content_read)
+    if content is None or len(content) < read_size:
+        raise FileContentReadException(read_size, content)
 
     return content

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     author_email="octocat@nym.hush.com",
     url="https://github.com/sjwood/pydvdid",
     install_requires=[
-        "pycdlib>=1.10.0"
+        "pycdlib>=1.10.0",
+        "python-dateutil>=2.8.1"
     ],
     packages=[
         "pydvdid"

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,15 @@ with open('README.rst') as readme_file:
 
 setup(
     name="pydvdid",
-    version="1.1",
+    version="1.2",
     description="A pure Python implementation of the Windows API IDvdInfo2::GetDiscID method, as used by Windows Media Center to compute a 'practically unique' 64-bit CRC for metadata retrieval.", # pylint: disable=locally-disabled, line-too-long
     long_description=README,
     author="Steve Wood",
     author_email="octocat@nym.hush.com",
     url="https://github.com/sjwood/pydvdid",
+    install_requires=[
+        "pycdlib>=1.10.0"
+    ],
     packages=[
         "pydvdid"
     ],
@@ -38,6 +41,8 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Home Automation",
         "Topic :: Multimedia :: Video",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
There's various reasons why this is needed, but the main one being speed and remove the need for auto-mounting if the device wasn't mounted.

With this method of reading the disc's data, you never need to mount the device, we read all the needed data right from the device's sectors.

I tested current master branch and this commit and confirmed that this is producing 1:1 identical checksums.

I updated the setup.py to include the pycdlib requirement as well as slightly updated README